### PR TITLE
Add automated neurocontainers recipe generation

### DIFF
--- a/.github/workflows/publish_recipe.yml
+++ b/.github/workflows/publish_recipe.yml
@@ -1,0 +1,107 @@
+name: publish neurocontainer recipe
+
+# On a version tag (e.g. v1.0.19), regenerate the neurocontainers recipe from
+# container/manifest.yaml + container/build.yaml.tmpl and open a PR against
+# neurodesk/neurocontainers from your fork. Also runnable by hand
+# (workflow_dispatch) with dry_run: true to just render and inspect the output.
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to publish (e.g. 1.0.19). Defaults to the triggering tag."
+        required: false
+      commit:
+        description: "Commit SHA to pin. Defaults to the checked-out commit."
+        required: false
+      dry_run:
+        description: "Render only; do not open a PR."
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+
+env:
+  # Your fork of neurocontainers that the PR branch is pushed to.
+  FORK: felenitaribeiro/neurocontainers
+  UPSTREAM: neurodesk/neurocontainers
+  RECIPE_PATH: recipes/deepretinotopy/build.yaml
+
+jobs:
+  render-and-pr:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout deepRetinotopy_TheToolbox
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install renderer dependencies
+        run: pip install pyyaml
+
+      - name: Resolve version and commit
+        id: vars
+        run: |
+          version="${{ github.event.inputs.version }}"
+          if [ -z "$version" ]; then version="${GITHUB_REF_NAME#v}"; fi
+          commit="${{ github.event.inputs.commit }}"
+          if [ -z "$commit" ]; then commit="${GITHUB_SHA}"; fi
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "commit=$commit" >> "$GITHUB_OUTPUT"
+          echo "Publishing deepretinotopy $version @ $commit"
+
+      - name: Render build.yaml
+        run: |
+          python container/render_recipe.py \
+            --version "${{ steps.vars.outputs.version }}" \
+            --commit "${{ steps.vars.outputs.commit }}" \
+            --output "${RUNNER_TEMP}/build.yaml"
+          echo "::group::rendered recipe"
+          cat "${RUNNER_TEMP}/build.yaml"
+          echo "::endgroup::"
+
+      - name: Checkout upstream neurocontainers
+        if: ${{ github.event.inputs.dry_run != 'true' }}
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ env.UPSTREAM }}
+          token: ${{ secrets.NEUROCONTAINERS_PAT }}
+          path: neurocontainers
+          fetch-depth: 0
+
+      - name: Copy rendered recipe into place
+        if: ${{ github.event.inputs.dry_run != 'true' }}
+        run: |
+          mkdir -p "neurocontainers/$(dirname "$RECIPE_PATH")"
+          cp "${RUNNER_TEMP}/build.yaml" "neurocontainers/${RECIPE_PATH}"
+
+      - name: Open pull request
+        if: ${{ github.event.inputs.dry_run != 'true' }}
+        uses: peter-evans/create-pull-request@v6
+        with:
+          token: ${{ secrets.NEUROCONTAINERS_PAT }}
+          path: neurocontainers
+          push-to-fork: ${{ env.FORK }}
+          base: main
+          branch: deepretinotopy-${{ steps.vars.outputs.version }}
+          delete-branch: true
+          commit-message: "deepretinotopy ${{ steps.vars.outputs.version }}"
+          title: "deepretinotopy ${{ steps.vars.outputs.version }}"
+          body: |
+            Automated recipe update for **deepretinotopy ${{ steps.vars.outputs.version }}**.
+
+            - version: `${{ steps.vars.outputs.version }}`
+            - pinned commit: `${{ steps.vars.outputs.commit }}`
+
+            Generated from `container/manifest.yaml` via `container/render_recipe.py`
+            in [deepRetinotopy_TheToolbox](https://github.com/felenitaribeiro/deepRetinotopy_TheToolbox).
+            Do not edit the recipe by hand -- change the manifest/template and re-tag.

--- a/container/README.md
+++ b/container/README.md
@@ -1,0 +1,57 @@
+# Container recipe automation
+
+This directory generates the [Neurodesk](https://www.neurodesk.org/) build recipe
+for deepretinotopy so it no longer has to be hand-edited in
+[neurodesk/neurocontainers](https://github.com/neurodesk/neurocontainers/blob/main/recipes/deepretinotopy/build.yaml).
+
+| File | Role |
+|------|------|
+| `manifest.yaml` | **Source of truth.** Model-seed selection per map/hemisphere and the OSF project. |
+| `build.yaml.tmpl` | The recipe with three holes (`@@VERSION@@`, `@@COMMIT@@`, `@@MODEL_FILES@@`). |
+| `render_recipe.py` | Fills the template from the manifest + git tag/commit and prints/writes `build.yaml`. |
+
+The published `recipes/deepretinotopy/build.yaml` is a **generated artifact** — never
+edit it by hand. Change the manifest (or, for structural changes, the template) and
+re-render.
+
+## Cutting a release
+
+1. Update `manifest.yaml` if the shipped model seeds changed (usually the only edit).
+2. Tag the release: `git tag v1.0.19 && git push --tags`.
+3. The [`publish neurocontainer recipe`](../.github/workflows/publish_recipe.yml)
+   workflow renders the recipe and opens a PR to neurocontainers from your fork.
+4. Review the PR diff (version, commit, changed seeds) and merge upstream.
+
+`version` comes from the tag; the pinned `commit` is the tagged commit — both are
+injected by the workflow, not stored in the manifest.
+
+## Rendering locally
+
+```bash
+pip install pyyaml
+python container/render_recipe.py                         # uses the latest git tag
+python container/render_recipe.py --version 1.0.19 --commit <sha> -o build.yaml
+```
+
+The renderer validates that no `@@token@@` is left unresolved and that the output
+parses as YAML. It reproduces the published 1.0.18 recipe byte-for-byte:
+
+```bash
+python container/render_recipe.py --version 1.0.18 \
+  --commit fd8382bfa168727feb53946fdab4fe838908e5f2
+```
+
+## One-time CI setup
+
+The workflow opens a cross-repo PR, which needs credentials the default
+`GITHUB_TOKEN` can't provide:
+
+1. Fork `neurodesk/neurocontainers` to `felenitaribeiro/neurocontainers` (if not
+   already). The `FORK`/`UPSTREAM` names are set at the top of the workflow.
+2. Create a Personal Access Token with write access to your fork
+   (fine-grained: *Contents* + *Pull requests* read/write; or a classic `repo` token).
+3. Add it as the repository secret **`NEUROCONTAINERS_PAT`**
+   (Settings → Secrets and variables → Actions).
+
+Run the workflow manually with **dry_run: true** first to render and inspect the
+recipe without opening a PR.

--- a/container/build.yaml.tmpl
+++ b/container/build.yaml.tmpl
@@ -1,0 +1,126 @@
+name: deepretinotopy
+version: @@VERSION@@
+
+copyright:
+  - license: GPL-3.0
+    url: https://github.com/felenitaribeiro/deepRetinotopy_TheToolbox/blob/main/LICENSE
+
+architectures:
+  - x86_64
+
+build:
+  kind: neurodocker
+
+  base-image: ghcr.io/neurodesk/freesurfer_7.3.2:20230216
+  pkg-manager: yum
+
+  # Delete the line containing localedef which is added automatically by NeuroDocker.
+  fix-locale-def: true
+
+  directives:
+    - install:
+        - git
+
+    - template:
+        name: miniconda
+        conda_install: python=3.12.8
+        pip_install: packaging osfclient==0.0.5 nibabel sympy==1.13.1
+        version: latest
+
+    - run:
+        - pip install --no-cache-dir torch==2.5.1 torchvision==0.20.1 --index-url https://download.pytorch.org/whl/cu124
+        - pip install --no-cache-dir pyg_lib torch_scatter torch_sparse torch_cluster torch_spline_conv -f https://data.pyg.org/whl/torch-2.5.1+cu124.html
+        - pip install --no-cache-dir torch_geometric==2.6.1
+        - python -c "import torch" 2>/dev/null || { echo "Failed to import module"; exit 1; }
+        - python -c "import torch_geometric; print('PyG working')"
+
+    - workdir: /opt
+
+    - run:
+        - git clone https://github.com/felenitaribeiro/deepRetinotopy_TheToolbox.git
+        - cd deepRetinotopy_TheToolbox
+        - git checkout @@COMMIT@@
+        - for file in @@MODEL_FILES@@; do path="${file#osfstorage/new_}"; mkdir -p "${path%/*}"; chmod 777 "${path%/*}"; osf -p ermbz fetch "$file" "$path"; echo "$file"; new_path=$(echo "$path" | sed -E 's/model[0-9]+/model/'); mv "$path" "$new_path"; echo "Renamed $path to $new_path"; done
+
+    - run:
+        - yum clean all
+        - rm -rf /var/cache/yum/*
+        - rm -rf /var/cache/dnf/*
+        - rm -rf /var/lib/dnf/history.sqlite*
+        - rm -rf /var/lib/rpm/Packages
+        - rm -rf /tmp/*
+        - rm -rf ~/.cache/pip/*
+        - rm -rf /opt/miniconda/lib/python3.12/site-packages/torchvision/datasets/*
+        - rm -rf /opt/miniconda/lib/python3.12/site-packages/*/__pycache__/*
+
+    - workdir: /opt/deepRetinotopy_TheToolbox
+
+    - environment:
+        PATH: /opt/workbench/workbench/bin_rh_linux64/:/opt/deepRetinotopy_TheToolbox/:/opt/deepRetinotopy_TheToolbox/main/:/opt/deepRetinotopy_TheToolbox/utils/:$PATH
+
+deploy:
+  bins:
+    - wb_view
+    - wb_command
+    - wb_shortcuts
+    - python
+    - deepRetinotopy
+    - signMaps
+    - 1_native2fsaverage.sh
+    - 2_inference.py
+    - 3_fsaverage2native.sh
+    - 4_signmaps.py
+    - transform_polarangle_lh.py
+    - midthickness_surf.py
+
+readme: |-
+  ----------------------------------
+  ## deepretinotopy/{{ context.version }} ##
+
+  This container has FreeSurfer 7.3.2, Connectome Workbench v1.5.0, PyTorch 2.5.1 (gpu), and PyTorch geometric 2.6.1 (gpu). These packages are required for data preparation and model inference. 
+  Use this container for GPU/CPU inference.
+
+  Example:
+  ```
+  wb_command
+  wb_view
+  wb_shortcuts
+  deepRetinotopy
+  ```
+
+  More documentation can be found here: https://github.com/felenitaribeiro/deepRetinotopy_TheToolbox
+
+  To run the container outside of this environment: ml deepretinotopy/{{ context.version }}
+
+  Citation:
+  ```{% raw %}
+  @article{Ribeiro2022,
+    author = {Ribeiro, Fernanda L and Bollmann, Steffen and Cunnington, Ross and Puckett, Alexander M},
+    arxivId = {2203.08312},
+    journal = {arXiv},
+    keywords = {Geometric deep learning, high-resolution fMRI, vision, retinotopy, explainable AI},
+    title = {{An explainability framework for cortical surface-based deep learning}},
+    url = {https://arxiv.org/abs/2203.08312},
+    year = {2022}
+  }
+
+
+  @article{Ribeiro2021,
+    author = {Ribeiro, Fernanda L and Bollmann, Steffen and Puckett, Alexander M},
+    doi = {https://doi.org/10.1016/j.neuroimage.2021.118624},
+    issn = {1053-8119},
+    journal = {NeuroImage},
+    keywords = {cortical surface, high-resolution fMRI, machine learning, manifold, visual hierarchy,Vision},
+    pages = {118624},
+    title = {{Predicting the retinotopic organization of human visual cortex from anatomy using geometric deep learning}},
+    url = {https://www.sciencedirect.com/science/article/pii/S1053811921008971},
+    year = {2021}
+  }
+  {% endraw %}```
+
+  ----------------------------------
+
+categories:
+  - "machine learning"
+  - "functional imaging"
+icon: data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAEAAAABACAYAAACqaXHeAAANSUlEQVR4nOVZCVBUVxY9/ekGuqFZZW1AdrEBF1AWcUGNGOMyolFxHGtitDTRMhNiZsoap3TUDJaxnFhqJRm1oolmqImO42hixB0VSSCyu7EvssvWbE1j95u6Tz8yRIPBtapPVdf///3337v3vnvPve+1hDEGY4YAI4cAI4cAI4cAI4cAI4cAI4cAI4cAI4cAI4cAI4cAI4cAI4cAI4f0Me0vbItoMBhgECSQQnL/mQGCBKBdqoRJHi6RgYEJgORBvwFC8sp5gCAIXPm7d6pRVlz+UHkJKd+FjBs5uFlWyo3UW/lntY2XPGag5+oBooJ0vZaZhUMtlfjnJT006a3Y8bYn3pkzFjX1tdj69klovh2BweYahC7PRdRf4wCJDJaWCkilsmfiAZIXbQBReQMzIDc1B/GFa5Hm1gGTS1ZoHxIDuy4nVP52NvIyinAlsh2LzLSws96KC+3X0PblZ1B5D0ZTYyPUajWcnZ3vK0He8mSQPCkHPBeIxm5pacGF5PNwtfOAqhaYEXYZpsus0SK7gYJ/m6KlfQIUli0whMxBc1AdlCpAWW8OQd6Jbj2DuZkpsrKyMG3atKeWScBLMEB2djbMZGbQS3VYM+5vmNf+LxQftIB7cQnU/nWoVRhQfz0Pdf5/Qd0fLuG4KhDOMV3IyrwGC7kCVVVVnDwvXbqE7u7up+IDAS8IJCQRHq2cUqlEZ6cWgiCFzNSAK3m+GO77EaYb3kFt5gwUGHSw7GiAzGoEIkKi4B2QgF3frEbcyo0wkegxJWYqpk+fDm9vb+Tk5PTwyStrAPYg7mtra3HhwgU4ODggPDwCbipnXLl6A6nVqZgyuh2D9SswQ/Un5LcUoaOpHZ6BXsgvvA31SBWcmT1SLhfCytoGOTm5uHXrFh/n7t27D7PGqx4Czc3NWLx4McrKyrB79y60tDRjzvzFcFf7oSKrGG2SNkwJ9Ub5nWaUVHVgSKArdN1anLxwBpY2CnTcZWhsuovIyEh0dnYiPT0djY2N90nVYHh1DSCRSKDRaHDt2jUuOIXCmDFjYGtnj5TkU7h16huMCB0GMwslTh/5AuhwRUmXK+wc2tHZ0Y0h/n5Q3LOBiQxoa7uL7OwcWFtbw97enmcCnU736noA68X8VlZWqK+vh4mJCYYNG4aMjEwM8XeDp/sM3Goth5XSDDNfHwuFVolUEy2qyn+Cn28Akk+fQkqBDMNGOyAyIhqka0NDAydDJycnzisD5QEBLwj37t1DYGAgCgsL+cpR7CqVNrCxU2BB+DjsONCIurYMDBpkC4emfJiGmkGnb0BlbSYizULgMmwM/HyV6OjoQnBwEOzs7LgBTp8+zTPBQCHFc4ZIUBT3FK+vvfYaCgoKuAKurq745JO/481ZsZgUthKZtknounkeyrQuNHp6Q+PQAlUXQ1L2DIz7vRaXk69AKrWEra0N96CioiJYWFhAr9f/31yvlAdIHgjk5uaG6OhopKSkYO/evejq6kJ7eztGjQqD71AfRHUXI+EzLXRqDWQlanQ3eUChKMDONaWoG1oEZ0cNwsMmIDBQDa1WywlVLpdj7NixPR4wEB4Q8IJALJ2bmwtPT08sX74cCoWCr2D0hPEwQIbBLhJ8GDYZnx6rhuBogWkTnJB8VUDMwjXwGl6PovwaSGUm/DsiveTkZNjY2GDPnj3w8vIasFzCM9XylyYSBDQ1NaG6upqvWEVFBWxtbXHo669RXlYKe1dvLJrkBtc0LTqC6zDTpRWXWmVwGHcbAZ7D4apyxtWrqdwAo0aN4h5laWmJkSNHDmRP8FAu9AOKLyIwug6EZUWh3N3d4evry6s3KmIoK5ASZAQnR0ekpGehKPcYglvHId27Cra5t9BZJSCp/gvYmQ1CgDoAUqkJH8vMzAyVlZWcBE1NTXkoDLQOkPbXgVLWIw8xDAa+qvQTjUN96Sr+6FksUkjo8vJyHrvz5s3jbkzfTX/jDVxKTcdvJngjO+FH/KfNC8G+edBnN8Cp4nUk1ubBWZOIscFv4vr163xMMhoZkryhtbX1+ZbCJ06cwK5du3DkyJEexfghhlTKr6Ki9EyCUFvv597w8PDg/akkPnnyJC5evIA7lXUoKfwBVzZfxaG6aKRafooF5k6wjIzAItti+P53LrbXNCOt6nusWPEulFZKnDlzhhMhrf7TQtLfeQClqhkzZvA0Rqt4/Phxvguj1aCU5ufnh2PHjnGlFixYgLq6OmRmZnL3pJUmN+99AELur1KpkJ6eBjeVO6yd7WFIOY4N65UoXA4s9MvGAvUaNDMdtCXfIXmXJQ7IvRE+NxGfTN+C/II7KCku4AWVo6MjIiIi+ObqCTng1x+IBAQEcC8gRcn1du7ciY8//hhBQUHIz8/HsmXLsG/fPl7cDBo0CP7+/jh//jw/sKCi5+zZs9zVRe8g5icGnzp1KlKupqOrIw/2Pw3F6qJ6vL2uFMs9l4OZ2aC1uQnZBfnwkFbg6w0+uDCzDLG2N7AoehXcvVxx8eJFzv40nxiOT7LgfRuE/r4gsqIa/vPPP+dERvn7zp07PKe/9dZbfLWpbe7cuZgyZQrP7fRu1qxZnKj4rA+UJ2OT0LRy3TodLG2soasoRFZtAIYuDkR8+Ls4/t1VdHZooO3SwtNRBcehMZg1oQP2mjcg8bXAYC8XfH/qFMzNzXtC6gmVfySE/jrExMTg4MGDSEpKwoEDB7BkyRIsXLgQaWlpfIOzdu1anoroWSaT8Xo/MTGR88aOHTt+Nh4Zg0KHNjRuHg7wd4lAXlsFmm5+i6KcGoyOHAFzMznf7Gi17XBTDYbSywDljTpYBDqirCQPhQUl8PX14UZ4WkgGeiZIuzpKPyKIjSkWN23axN9t2bKFt5P7984kIh/UVNcgLz8D1clXcLE4DnXD9uL9oIlQeQTD0lLOx05KOo3ZsTNxePdXOPiNNdSbM7Fl/Pu4fbMZIaFBAyl9n82ZoF6v78m99CMhRCJav349rxtE4UTlRUOLmcTZxRmOLq/j26xUlN25iKAVoZDqgB9Sf8Si3y3gczg6OKCquhqthfUY5DUErVor3L6Zi8GDI2AwUP0v6Zmndyrse/9LkD7uhTgwERqRHcU2ZQSKbdqAkJJiKiSQIdra2ni5GxUVxdvi4+M5Ma5bt65HEPFquGeAxESC8eFhKCqdijxJEhxcLDAseCKyc7Lh6uKKqKhxqKotxIQhQSjUTYbP1EaEyMcDsHisvCKe1DOEx70QK6uEhASsXLmSb2KWLl2K2NhYPhkpX1NTw1MiESUZ4vDhw3xzQic1RIw+Pj6cOAmUJik0yJi0KxSkwv0iyVrAtR+OQXO3FWr/MZAr5Jg8eTI2bNiAtnYNfLwCIcjlOHXlGEzKSrnyegPj22ky+M2bN/nZAI1FZTbNQbJ3dHTwOfsF61W59fqxe/fu0YVNmzaNhYWF8fvZs2czhULB7xMTE9nIkSPZ4sWLmZ+fH8vPz2exsbFMEAQ2fPhwlpmZyd+tWrWK9/f09GQjRoxgjo6OzM3NjTU1NbEbN26wyDHh7I8fxrPQ8BB26OAhlpSUxExNTZmzszN77733WGFhIYsMC2UfrolnE8ZHse3bt/PxAgMD+Xg0N/Wtra1l8+bNY9HR0fz9xIkTWVxcHOuty6N0RX8GmDNnDpPL5VxoCwsLdv78eabX6/nz6NGj2ebNmynY2LZt29jly5eZRCJhZWVlzGAwcEOQUQhkmISEBG4o6p+RkcHi4+PZ/i+/4u8LikpZREQ40+l0zN3dna1Zs4bLQAb8x959vE95ZQ0bFRrKWltbmZOTE/vggw9Ye3s7n3P37t0sJSWFj01XExMTdu7cuX4NIPTnIeRmVNRs3bqV8wC5Pbk7laJEhPTu6NGjPLVRJqBBKYWRS1JaFMtV+oY4hHK3uD9gEgFWMobGjNPQN5TB1FzB8w+FD5En/cjde/rUF0NuoeT8Q+PRcRjtB2hOko3OGWm7HRcXh9DQUEyaNKmnVB9wCMTExHBXJ6xevZpbODs7m+3fv5+5uLiw+fPns6ioKHb48GFWWlrKvSUkJITl5uZyd5w7dy7/llZkz549TKPR9KxSZnYOC/Z0ZlEqU6Z2NGdbt91371mzZjFbW1u2bt2fWVZuHgsd4sGiXGVsqIMZ27jpI97Hx8eHqdVqFhwczHx9fVlFRQX3OgoRGn/v3r28X3d3t7j6vy4EDAYD/4LcmeJQNEheXh5vIxQXF7OjR4+y5ORk7oqEoqIidubMGa4o9SsvL+ft169fZ42NjTx86J7eEyoqq9iJpLMsIyevR0qtVsvDKSsriz9X19axE0nnWNq1zJ4+FI5Llizhczc0NPS0b9y4kRugubmZ6yDq8asN0B9Ikb7oM9kTjGHo9/u+84h9li5dyo3ftx8RJ3HNY2T8ma6S/ipBMR32zvdi4cHj+EH+7f1ejLu+fR91T33FZ3GMvm2P6tNbPnGsvqH9iFrg5f89/qzQe4fZG70X4BF4YgMYDQQYOQQYOQQYOQQYOQQYOQQYOQQYOQQYOQQYOQQYOQQYOQQYOQQYOYSXLcDLxv8A5CvvRn7OMVIAAAAASUVORK5CYII=

--- a/container/manifest.yaml
+++ b/container/manifest.yaml
@@ -1,0 +1,28 @@
+# Source of truth for the deepretinotopy Neurodesk container recipe.
+#
+# `container/render_recipe.py` reads this file plus the current git tag/commit
+# and fills `container/build.yaml.tmpl` to produce the neurocontainers recipe
+# (recipes/deepretinotopy/build.yaml). The recipe is a generated artifact --
+# edit *this* file (or the template), never the rendered YAML by hand.
+#
+# Per release you normally only touch `models` below (the best-performing seed
+# picked for each map/hemisphere). `version` and `commit` come from git and are
+# supplied by the renderer / CI, not stored here.
+
+# OSF project that hosts the trained model weights, and the path prefix within
+# it. Files are fetched as: <osf_model_dir>/deepRetinotopy_<map>_<hemi>_model<seed>.pt
+osf_project: ermbz
+osf_model_dir: osfstorage/new_models
+
+# Which trained seed ships for each hemisphere + map. The renderer emits the
+# download list in a fixed order (LH block first, then RH; within each,
+# polarAngle, eccentricity, pRFsize) regardless of the ordering here.
+models:
+  LH:
+    polarAngle: 5
+    eccentricity: 2
+    pRFsize: 5
+  RH:
+    polarAngle: 4
+    eccentricity: 2
+    pRFsize: 5

--- a/container/render_recipe.py
+++ b/container/render_recipe.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+"""Render the deepretinotopy neurocontainers recipe from the manifest + template.
+
+The published recipe (neurodesk/neurocontainers recipes/deepretinotopy/build.yaml)
+only differs from release to release in four spots: the version, the pinned commit,
+the list of model weights to fetch, and the CPU-version note in the readme. This
+script fills those into container/build.yaml.tmpl from container/manifest.yaml and
+the current git tag/commit, so the recipe is generated rather than hand-edited.
+
+Usage:
+    python container/render_recipe.py                       # infer version/commit from git
+    python container/render_recipe.py --version 1.0.19 --commit <sha>
+    python container/render_recipe.py -o /tmp/build.yaml    # write somewhere else
+
+With no --output, the rendered recipe is printed to stdout.
+"""
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+from pathlib import Path
+
+import yaml
+
+HERE = Path(__file__).resolve().parent
+DEFAULT_MANIFEST = HERE / "manifest.yaml"
+DEFAULT_TEMPLATE = HERE / "build.yaml.tmpl"
+
+# Fixed emission order for the model download loop (matches the published recipe).
+HEMIS = ("LH", "RH")
+MAPS = ("polarAngle", "eccentricity", "pRFsize")
+
+
+def _git(*args: str) -> str:
+    return subprocess.check_output(["git", *args], cwd=HERE, text=True).strip()
+
+
+def latest_tag() -> str:
+    """Most recent tag reachable from HEAD (e.g. 'v1.0.6')."""
+    return _git("describe", "--tags", "--abbrev=0")
+
+
+def commit_for_ref(ref: str) -> str:
+    """Full commit SHA that a ref (tag/branch/HEAD) points to."""
+    return _git("rev-list", "-n", "1", ref)
+
+
+def build_model_files(manifest: dict) -> str:
+    prefix = manifest["osf_model_dir"].rstrip("/")
+    models = manifest["models"]
+    files = []
+    for hemi in HEMIS:
+        for m in MAPS:
+            seed = models[hemi][m]
+            files.append(f"{prefix}/deepRetinotopy_{m}_{hemi}_model{seed}.pt")
+    return " ".join(files)
+
+
+def render(version: str, commit: str, manifest_path: Path, template_path: Path) -> str:
+    manifest = yaml.safe_load(manifest_path.read_text())
+    template = template_path.read_text()
+
+    substitutions = {
+        "@@VERSION@@": version,
+        "@@COMMIT@@": commit,
+        "@@MODEL_FILES@@": build_model_files(manifest),
+    }
+    out = template
+    for token, value in substitutions.items():
+        if token not in out:
+            raise SystemExit(f"error: token {token} missing from template {template_path}")
+        out = out.replace(token, value)
+
+    if "@@" in out:
+        raise SystemExit("error: unresolved @@...@@ token remains in rendered recipe")
+
+    # Sanity check: the result must be valid YAML.
+    yaml.safe_load(out)
+    return out
+
+
+def main(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    p.add_argument("--version", help="Version string (default: latest git tag, leading 'v' stripped).")
+    p.add_argument("--commit", help="Commit SHA to pin (default: the commit the version tag points to).")
+    p.add_argument("--manifest", type=Path, default=DEFAULT_MANIFEST)
+    p.add_argument("--template", type=Path, default=DEFAULT_TEMPLATE)
+    p.add_argument("-o", "--output", type=Path, help="Write here instead of stdout.")
+    args = p.parse_args(argv)
+
+    version = args.version
+    commit = args.commit
+    if version is None or commit is None:
+        tag = latest_tag()
+        if version is None:
+            version = tag[1:] if tag.startswith("v") else tag
+        if commit is None:
+            commit = commit_for_ref(tag)
+
+    recipe = render(version, commit, args.manifest, args.template)
+
+    if args.output:
+        args.output.write_text(recipe)
+        print(f"wrote {args.output} (version={version}, commit={commit})", file=sys.stderr)
+    else:
+        sys.stdout.write(recipe)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Generate the Neurodesk build.yaml from a manifest + template instead of hand-editing the recipe in neurocontainers on every release.

- container/manifest.yaml: source of truth for model-seed selection + OSF project
- container/build.yaml.tmpl: recipe with @@VERSION@@/@@COMMIT@@/@@MODEL_FILES@@ holes
- container/render_recipe.py: fills the template from the manifest + git tag/commit
- .github/workflows/publish_recipe.yml: on a v* tag, render and open a PR to neurocontainers from the fork (dry_run supported for manual checks)
- container/README.md: release flow + one-time CI setup

Reproduces the published 1.0.18 recipe byte-for-byte; drops the stale CPU-version note.